### PR TITLE
Added project folder for Moonwell deployment on Moonriver

### DIFF
--- a/projects/moonwell-apollo/moonwell-apollo.json
+++ b/projects/moonwell-apollo/moonwell-apollo.json
@@ -3,7 +3,7 @@
   "slug": "moonwell-apollo",
   "name": "Moonwell Apollo",
   "category": "lending",
-  "coinGeckoId": "moonwell-apollo",
+  "coinGeckoId": "moonwell",
   "chains": [
     "moonriver"
   ],

--- a/projects/moonwell/moonwell.json
+++ b/projects/moonwell/moonwell.json
@@ -3,7 +3,7 @@
   "slug": "moonwell",
   "name": "Moonwell",
   "category": "lending",
-  "coinGeckoId": "moonwell",
+  "coinGeckoId": "moonwell-artemis",
   "chains": [
     "moonbeam"
   ],


### PR DESCRIPTION
Initial, simple PR to add a Project folder for Moonwell Apollo.

@Rihyx - can you copy the moonwell logo and screen shot folders into the moonwell-apollo folder?  We'll use those as a baseline for now and overwrite as needed.

Thanks